### PR TITLE
feat(monitoring): restore app observability with nginx exporter

### DIFF
--- a/monitoring/README.md
+++ b/monitoring/README.md
@@ -73,19 +73,15 @@ vim .env
 
 **수정 필요 항목:**
 ```bash
-# MySQL (systemd로 실행 중인 서비스 연결)
-MYSQL_HOST=localhost
-MYSQL_PORT=3306
-MYSQL_EXPORTER_USER=exporter         # MySQL 계정 생성 필요
+# MySQL Exporter 계정 비밀번호와 exporter.cnf를 동일하게 맞춰야 함
+MYSQL_EXPORTER_USER=exporter
 MYSQL_EXPORTER_PASSWORD=your_password
 
-# Redis
-REDIS_HOST=localhost
-REDIS_PORT=6379
-
-# MongoDB
-MONGO_HOST=localhost
-MONGO_PORT=27017
+# Nginx Exporter scrape URI
+# 기본: dev 환경 (/nginx_status)
+NGINX_SCRAPE_URI=http://127.0.0.1/nginx_status
+# prod 로컬 전용 status 포트 예시
+# NGINX_SCRAPE_URI=http://127.0.0.1:18080/nginx_status
 ```
 
 **MySQL Exporter 계정 생성:**
@@ -94,7 +90,9 @@ MONGO_PORT=27017
 mysql -u root -p < mysql/init_exporter.sql
 # 또는 수동:
 # CREATE USER 'exporter'@'localhost' IDENTIFIED BY 'password';
+# CREATE USER 'exporter'@'127.0.0.1' IDENTIFIED BY 'password';
 # GRANT PROCESS, REPLICATION CLIENT, SELECT ON *.* TO 'exporter'@'localhost';
+# GRANT PROCESS, REPLICATION CLIENT, SELECT ON *.* TO 'exporter'@'127.0.0.1';
 ```
 
 ```bash
@@ -135,6 +133,30 @@ docker ps
 curl localhost:9100/metrics  # Node Exporter
 curl localhost:8082/metrics  # cAdvisor
 curl localhost:9104/metrics  # MySQL Exporter
+curl localhost:9113/metrics  # Nginx Exporter
+curl localhost:9104/metrics | grep '^mysql_up'   # mysql_up 1 확인
+curl localhost:9113/metrics | grep '^nginx_up'   # nginx_up 1 확인
+```
+
+### Prod에서 로컬 전용 Nginx status 엔드포인트를 쓰는 경우
+```nginx
+# /etc/nginx/conf.d/monitoring-status.conf
+server {
+    listen 127.0.0.1:18080;
+    server_name localhost;
+
+    location = /nginx_status {
+        stub_status on;
+        access_log off;
+        allow 127.0.0.1;
+        deny all;
+    }
+}
+```
+
+```bash
+sudo nginx -t
+sudo systemctl reload nginx   # restart 금지 (무중단)
 ```
 
 ## 포트 목록
@@ -148,6 +170,7 @@ curl localhost:9104/metrics  # MySQL Exporter
 - `9100`: Node Exporter (시스템 메트릭)
 - `8082`: cAdvisor (컨테이너 메트릭)
 - `9104`: MySQL Exporter
+- `9113`: Nginx Exporter
 
 ## 보안 그룹 설정
 
@@ -156,7 +179,7 @@ curl localhost:9104/metrics  # MySQL Exporter
 - Outbound: All (EC2 Service Discovery용)
 
 ### 타겟 서버
-- Inbound: 9100, 8082, 9104 - 모니터링 서버 IP만 허용
+- Inbound: 9100, 8082, 9104, 9113 - 모니터링 서버 IP만 허용
 
 ## 문제 해결
 
@@ -172,5 +195,14 @@ curl localhost:9104/metrics  # MySQL Exporter
 
 ### MySQL Exporter 연결 실패
 1. MySQL exporter 계정 생성 확인
-2. `MYSQL_HOST`가 `localhost`인지 확인 (systemd 서비스)
-3. MySQL 포트 확인 (`MYSQL_PORT`)
+2. `mysql/exporter.cnf`의 `host`가 `127.0.0.1`인지 확인
+3. 계정 권한과 비밀번호 일치 확인 (`Access denied` 여부)
+
+### Nginx Exporter 연결 실패
+1. 타겟 서버에서 `curl localhost:9113/metrics` 확인 (`nginx_up 1`)
+2. `NGINX_SCRAPE_URI`가 실제 status 엔드포인트와 일치하는지 확인
+3. 보안 그룹에 `9113/tcp` 인바운드 허용 여부 확인
+
+### Grafana dev/prod 분리 보기
+1. `Billage App Observability` 대시보드 열기
+2. 상단 `Environment` 변수에서 `dev`, `prod`, `All` 선택

--- a/monitoring/server/configs/grafana/dashboards/app-observability.json
+++ b/monitoring/server/configs/grafana/dashboards/app-observability.json
@@ -1,0 +1,408 @@
+{
+  "annotations": {
+    "list": [
+      {
+        "builtIn": 1,
+        "datasource": {
+          "type": "grafana",
+          "uid": "-- Grafana --"
+        },
+        "enable": true,
+        "hide": true,
+        "iconColor": "rgba(0, 211, 255, 1)",
+        "name": "Annotations & Alerts",
+        "type": "dashboard"
+      }
+    ]
+  },
+  "editable": true,
+  "fiscalYearStartMonth": 0,
+  "graphTooltip": 0,
+  "id": null,
+  "links": [],
+  "liveNow": false,
+  "panels": [
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "reqps"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 8,
+        "x": 0,
+        "y": 0
+      },
+      "id": 1,
+      "options": {
+        "legend": {
+          "displayMode": "list",
+          "placement": "bottom"
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "targets": [
+        {
+          "expr": "sum by (instance) (rate(nginx_http_requests_total{job=\"ec2-nginx-exporter\",instance=~\".*$env.*\"}[1m]))",
+          "legendFormat": "{{instance}}",
+          "refId": "A"
+        }
+      ],
+      "title": "Nginx QPS",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "none"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 8,
+        "x": 8,
+        "y": 0
+      },
+      "id": 2,
+      "options": {
+        "legend": {
+          "displayMode": "list",
+          "placement": "bottom"
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "targets": [
+        {
+          "expr": "nginx_connections_active{job=\"ec2-nginx-exporter\",instance=~\".*$env.*\"}",
+          "legendFormat": "{{instance}}",
+          "refId": "A"
+        }
+      ],
+      "title": "Nginx Active Connections",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "reqps"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 8,
+        "x": 16,
+        "y": 0
+      },
+      "id": 3,
+      "options": {
+        "legend": {
+          "displayMode": "list",
+          "placement": "bottom"
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "targets": [
+        {
+          "expr": "sum by (instance) (rate(nginx_http_requests_total{job=\"ec2-nginx-exporter\",status=~\"5..\",instance=~\".*$env.*\"}[5m]))",
+          "legendFormat": "{{instance}}",
+          "refId": "A"
+        }
+      ],
+      "title": "Nginx 5xx/s",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "reqps"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 8,
+        "x": 0,
+        "y": 8
+      },
+      "id": 4,
+      "options": {
+        "legend": {
+          "displayMode": "list",
+          "placement": "bottom"
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "targets": [
+        {
+          "expr": "sum by (instance) (rate(http_server_requests_seconds_count{job=\"ec2-spring-actuator\",instance=~\".*$env.*\"}[1m]))",
+          "legendFormat": "{{instance}}",
+          "refId": "A"
+        }
+      ],
+      "title": "Spring QPS",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "percentunit",
+          "min": 0,
+          "max": 1
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 8,
+        "x": 8,
+        "y": 8
+      },
+      "id": 5,
+      "options": {
+        "legend": {
+          "displayMode": "list",
+          "placement": "bottom"
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "targets": [
+        {
+          "expr": "sum by (instance) (rate(http_server_requests_seconds_count{job=\"ec2-spring-actuator\",status=~\"5..\",instance=~\".*$env.*\"}[5m])) / sum by (instance) (rate(http_server_requests_seconds_count{job=\"ec2-spring-actuator\",instance=~\".*$env.*\"}[5m]))",
+          "legendFormat": "{{instance}}",
+          "refId": "A"
+        }
+      ],
+      "title": "Spring 5xx Ratio",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "ms"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 8,
+        "x": 16,
+        "y": 8
+      },
+      "id": 6,
+      "options": {
+        "legend": {
+          "displayMode": "list",
+          "placement": "bottom"
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "targets": [
+        {
+          "expr": "1000 * sum by (instance) (rate(http_server_requests_seconds_sum{job=\"ec2-spring-actuator\",instance=~\".*$env.*\"}[5m])) / sum by (instance) (rate(http_server_requests_seconds_count{job=\"ec2-spring-actuator\",instance=~\".*$env.*\"}[5m]))",
+          "legendFormat": "{{instance}}",
+          "refId": "A"
+        }
+      ],
+      "title": "Spring Avg Latency (ms)",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "none"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 8,
+        "x": 0,
+        "y": 16
+      },
+      "id": 7,
+      "options": {
+        "legend": {
+          "displayMode": "list",
+          "placement": "bottom"
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "targets": [
+        {
+          "expr": "mysql_up{job=\"ec2-mysql-exporter\",instance=~\".*$env.*\"}",
+          "legendFormat": "{{instance}}",
+          "refId": "A"
+        }
+      ],
+      "title": "MySQL Up",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "none"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 8,
+        "x": 8,
+        "y": 16
+      },
+      "id": 8,
+      "options": {
+        "legend": {
+          "displayMode": "list",
+          "placement": "bottom"
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "targets": [
+        {
+          "expr": "mysql_global_status_threads_connected{job=\"ec2-mysql-exporter\",instance=~\".*$env.*\"}",
+          "legendFormat": "{{instance}}",
+          "refId": "A"
+        }
+      ],
+      "title": "MySQL Threads Connected",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "reqps"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 8,
+        "x": 16,
+        "y": 16
+      },
+      "id": 9,
+      "options": {
+        "legend": {
+          "displayMode": "list",
+          "placement": "bottom"
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "targets": [
+        {
+          "expr": "rate(mysql_global_status_questions{job=\"ec2-mysql-exporter\",instance=~\".*$env.*\"}[1m])",
+          "legendFormat": "{{instance}}",
+          "refId": "A"
+        }
+      ],
+      "title": "MySQL QPS",
+      "type": "timeseries"
+    }
+  ],
+  "refresh": "10s",
+  "schemaVersion": 39,
+  "tags": [
+    "billage",
+    "nginx",
+    "spring",
+    "mysql",
+    "monitoring"
+  ],
+  "templating": {
+    "list": [
+      {
+        "name": "env",
+        "label": "Environment",
+        "type": "custom",
+        "query": "dev,prod",
+        "current": {
+          "selected": true,
+          "text": "All",
+          "value": ".*"
+        },
+        "includeAll": true,
+        "allValue": ".*",
+        "multi": false,
+        "options": []
+      }
+    ]
+  },
+  "time": {
+    "from": "now-6h",
+    "to": "now"
+  },
+  "timepicker": {},
+  "timezone": "browser",
+  "title": "Billage App Observability",
+  "uid": "billage-app-observability",
+  "version": 2,
+  "weekStart": ""
+}

--- a/monitoring/target/exporters/docker-compose.yml
+++ b/monitoring/target/exporters/docker-compose.yml
@@ -31,9 +31,17 @@ services:
     container_name: mysql-exporter
     network_mode: host
     restart: unless-stopped
-    env_file:
-      - .env
-    environment:
-      - DATA_SOURCE_NAME=${MYSQL_EXPORTER_USER}:${MYSQL_EXPORTER_PASSWORD}@tcp(127.0.0.1:${MYSQL_PORT})/
+    volumes:
+      - ./mysql/exporter.cnf:/.my.cnf
     command:
+      - '--config.my-cnf=/.my.cnf'
       - '--web.listen-address=:9104'
+
+  nginx-exporter:
+    image: nginx/nginx-prometheus-exporter:1.4.2
+    container_name: nginx-exporter
+    network_mode: host
+    restart: unless-stopped
+    command:
+      - '--nginx.scrape-uri=${NGINX_SCRAPE_URI:-http://127.0.0.1/nginx_status}'
+      - '--web.listen-address=:9113'


### PR DESCRIPTION
## Why
모니터링의 근본 목적은 "장애를 빠르게 감지하고 원인을 즉시 좁히는 것"입니다.
기존 상태는 Nginx 메트릭 공백(`ec2-nginx-exporter` DOWN)과 환경(dev/prod) 분리 조회 불가로 인해,
트래픽/에러/DB 상태를 운영 중에 즉시 판단하기 어려웠습니다.

## What
1. `monitoring/target/exporters/docker-compose.yml`
- `nginx-exporter` 추가 (`:9113`)
- `mysql-exporter`를 `exporter.cnf` 기반으로 정리 (`--config.my-cnf`)
- `NGINX_SCRAPE_URI` 환경변수로 dev/prod status endpoint 차이를 흡수

2. `monitoring/server/configs/grafana/dashboards/app-observability.json` (신규)
- Nginx/Spring/MySQL 핵심 지표 대시보드 추가
- Nginx QPS, connection, 5xx/s
- Spring QPS, 5xx ratio, avg latency
- MySQL up, threads connected, QPS
- `Environment` 필터(`All/dev/prod`) 추가

3. `monitoring/README.md`
- 9113 포트/SG 요구사항 반영
- Nginx exporter 설정/검증 절차 보강
- prod 로컬 전용 status endpoint 패턴(무중단 reload) 문서화
- dev/prod 필터 사용법 추가

## Outcome
- 모니터링이 "로그 위주"에서 "서비스 상태+트래픽+DB 헬스"로 확장됨
- 장애 시 dev/prod 환경을 즉시 분리해 원인 추적 가능
- 운영 무중단 원칙(restart 금지, reload 중심)과 맞는 적용 패턴 확보

Closes #86
