### PR TITLE
[#92] RabbitMQ single bootstrap + v2 ws 라우팅 추가

### DIFF
--- a/shared/rabbitmq/dev/.terraform.lock.hcl
+++ b/shared/rabbitmq/dev/.terraform.lock.hcl
@@ -1,0 +1,45 @@
+# This file is maintained automatically by "terraform init".
+# Manual edits may be lost in future updates.
+
+provider "registry.terraform.io/hashicorp/aws" {
+  version     = "5.100.0"
+  constraints = "~> 5.0"
+  hashes = [
+    "h1:Ijt7pOlB7Tr7maGQIqtsLFbl7pSMIj06TVdkoSBcYOw=",
+    "zh:054b8dd49f0549c9a7cc27d159e45327b7b65cf404da5e5a20da154b90b8a644",
+    "zh:0b97bf8d5e03d15d83cc40b0530a1f84b459354939ba6f135a0086c20ebbe6b2",
+    "zh:1589a2266af699cbd5d80737a0fe02e54ec9cf2ca54e7e00ac51c7359056f274",
+    "zh:6330766f1d85f01ae6ea90d1b214b8b74cc8c1badc4696b165b36ddd4cc15f7b",
+    "zh:7c8c2e30d8e55291b86fcb64bdf6c25489d538688545eb48fd74ad622e5d3862",
+    "zh:99b1003bd9bd32ee323544da897148f46a527f622dc3971af63ea3e251596342",
+    "zh:9b12af85486a96aedd8d7984b0ff811a4b42e3d88dad1a3fb4c0b580d04fa425",
+    "zh:9f8b909d3ec50ade83c8062290378b1ec553edef6a447c56dadc01a99f4eaa93",
+    "zh:aaef921ff9aabaf8b1869a86d692ebd24fbd4e12c21205034bb679b9caf883a2",
+    "zh:ac882313207aba00dd5a76dbd572a0ddc818bb9cbf5c9d61b28fe30efaec951e",
+    "zh:bb64e8aff37becab373a1a0cc1080990785304141af42ed6aa3dd4913b000421",
+    "zh:dfe495f6621df5540d9c92ad40b8067376350b005c637ea6efac5dc15028add4",
+    "zh:f0ddf0eaf052766cfe09dea8200a946519f653c384ab4336e2a4a64fdd6310e9",
+    "zh:f1b7e684f4c7ae1eed272b6de7d2049bb87a0275cb04dbb7cda6636f600699c9",
+    "zh:ff461571e3f233699bf690db319dfe46aec75e58726636a0d97dd9ac6e32fb70",
+  ]
+}
+
+provider "registry.terraform.io/hashicorp/random" {
+  version     = "3.8.1"
+  constraints = "~> 3.6"
+  hashes = [
+    "h1:u8AKlWVDTH5r9YLSeswoVEjiY72Rt4/ch7U+61ZDkiQ=",
+    "zh:08dd03b918c7b55713026037c5400c48af5b9f468f483463321bd18e17b907b4",
+    "zh:0eee654a5542dc1d41920bbf2419032d6f0d5625b03bd81339e5b33394a3e0ae",
+    "zh:229665ddf060aa0ed315597908483eee5b818a17d09b6417a0f52fd9405c4f57",
+    "zh:2469d2e48f28076254a2a3fc327f184914566d9e40c5780b8d96ebf7205f8bc0",
+    "zh:37d7eb334d9561f335e748280f5535a384a88675af9a9eac439d4cfd663bcb66",
+    "zh:741101426a2f2c52dee37122f0f4a2f2d6af6d852cb1db634480a86398fa3511",
+    "zh:78d5eefdd9e494defcb3c68d282b8f96630502cac21d1ea161f53cfe9bb483b3",
+    "zh:a902473f08ef8df62cfe6116bd6c157070a93f66622384300de235a533e9d4a9",
+    "zh:b85c511a23e57a2147355932b3b6dce2a11e856b941165793a0c3d7578d94d05",
+    "zh:c5172226d18eaac95b1daac80172287b69d4ce32750c82ad77fa0768be4ea4b8",
+    "zh:dab4434dba34aad569b0bc243c2d3f3ff86dd7740def373f2a49816bd2ff819b",
+    "zh:f49fd62aa8c5525a5c17abd51e27ca5e213881d58882fd42fec4a545b53c9699",
+  ]
+}

--- a/shared/rabbitmq/dev/backend.tf
+++ b/shared/rabbitmq/dev/backend.tf
@@ -1,0 +1,12 @@
+# shared/rabbitmq/dev/backend.tf
+# Terraform Backend 설정 - Dev RabbitMQ
+
+terraform {
+  backend "s3" {
+    bucket         = "billage-terraform-state-dev"
+    key            = "shared/rabbitmq/terraform.tfstate"
+    region         = "ap-northeast-2"
+    encrypt        = true
+    dynamodb_table = "billage-terraform-lock-dev"
+  }
+}

--- a/shared/rabbitmq/dev/main.tf
+++ b/shared/rabbitmq/dev/main.tf
@@ -1,0 +1,212 @@
+# shared/rabbitmq/dev/main.tf
+# WebSocket Pub/Sub용 RabbitMQ (Single Instance)
+
+terraform {
+  required_version = ">= 1.0.0"
+
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = "~> 5.0"
+    }
+    random = {
+      source  = "hashicorp/random"
+      version = "~> 3.6"
+    }
+  }
+}
+
+provider "aws" {
+  region = var.aws_region
+
+  default_tags {
+    tags = {
+      Project     = var.project_name
+      Environment = var.env
+      ManagedBy   = "terraform"
+      Component   = "shared-rabbitmq"
+    }
+  }
+}
+
+data "terraform_remote_state" "v1" {
+  backend = "s3"
+  config = {
+    bucket         = var.v1_state_bucket
+    key            = var.v1_state_key
+    region         = var.aws_region
+    dynamodb_table = var.v1_state_lock_table
+  }
+}
+
+data "terraform_remote_state" "v2" {
+  backend = "s3"
+  config = {
+    bucket         = var.v2_state_bucket
+    key            = var.v2_state_key
+    region         = var.aws_region
+    dynamodb_table = var.v2_state_lock_table
+  }
+}
+
+data "aws_vpc" "main" {
+  tags = {
+    Name = "${var.project_name}-${var.env}-vpc"
+  }
+}
+
+data "aws_ami" "amazon_linux" {
+  most_recent = true
+  owners      = ["amazon"]
+
+  filter {
+    name   = "name"
+    values = ["al2023-ami-*-x86_64"]
+  }
+
+  filter {
+    name   = "virtualization-type"
+    values = ["hvm"]
+  }
+}
+
+locals {
+  v1_main_sg_id      = data.terraform_remote_state.v1.outputs.main_security_group_id
+  v2_backend_sg_id   = data.terraform_remote_state.v2.outputs.security_group_ids.backend
+  rabbitmq_subnet_id = data.terraform_remote_state.v2.outputs.private_subnet_ids[0]
+}
+
+resource "random_password" "rabbitmq" {
+  length  = 32
+  special = false
+}
+
+resource "aws_iam_role" "rabbitmq" {
+  name = "${var.project_name}-${var.env}-rabbitmq-role"
+
+  assume_role_policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [{
+      Action = "sts:AssumeRole"
+      Effect = "Allow"
+      Principal = {
+        Service = "ec2.amazonaws.com"
+      }
+    }]
+  })
+}
+
+resource "aws_iam_role_policy_attachment" "ssm_core" {
+  role       = aws_iam_role.rabbitmq.name
+  policy_arn = "arn:aws:iam::aws:policy/AmazonSSMManagedInstanceCore"
+}
+
+resource "aws_iam_role_policy_attachment" "cloudwatch_agent" {
+  role       = aws_iam_role.rabbitmq.name
+  policy_arn = "arn:aws:iam::aws:policy/CloudWatchAgentServerPolicy"
+}
+
+resource "aws_iam_instance_profile" "rabbitmq" {
+  name = "${var.project_name}-${var.env}-rabbitmq-profile"
+  role = aws_iam_role.rabbitmq.name
+}
+
+resource "aws_security_group" "rabbitmq" {
+  name        = "${var.project_name}-${var.env}-rabbitmq-sg"
+  description = "Security group for RabbitMQ broker"
+  vpc_id      = data.aws_vpc.main.id
+
+  ingress {
+    description     = "AMQP from v1/v2 backend security groups"
+    from_port       = 5672
+    to_port         = 5672
+    protocol        = "tcp"
+    security_groups = [local.v1_main_sg_id, local.v2_backend_sg_id]
+  }
+
+  ingress {
+    description     = "STOMP from v1/v2 backend security groups"
+    from_port       = 61613
+    to_port         = 61613
+    protocol        = "tcp"
+    security_groups = [local.v1_main_sg_id, local.v2_backend_sg_id]
+  }
+
+  ingress {
+    description = "RabbitMQ Management UI"
+    from_port   = 15672
+    to_port     = 15672
+    protocol    = "tcp"
+    cidr_blocks = var.management_access_cidrs
+  }
+
+  ingress {
+    description = "SSH for operations"
+    from_port   = 22
+    to_port     = 22
+    protocol    = "tcp"
+    cidr_blocks = var.management_access_cidrs
+  }
+
+  egress {
+    description = "Allow all outbound"
+    from_port   = 0
+    to_port     = 0
+    protocol    = "-1"
+    cidr_blocks = ["0.0.0.0/0"]
+  }
+
+  tags = {
+    Name = "${var.project_name}-${var.env}-rabbitmq-sg"
+  }
+}
+
+resource "aws_instance" "rabbitmq" {
+  ami                         = data.aws_ami.amazon_linux.id
+  instance_type               = var.instance_type
+  subnet_id                   = local.rabbitmq_subnet_id
+  vpc_security_group_ids      = [aws_security_group.rabbitmq.id]
+  iam_instance_profile        = aws_iam_instance_profile.rabbitmq.name
+  key_name                    = var.key_name
+  associate_public_ip_address = false
+
+  user_data = templatefile("${path.module}/user_data_rabbitmq.sh.tpl", {
+    rabbitmq_username = var.rabbitmq_username
+    rabbitmq_password = random_password.rabbitmq.result
+  })
+
+  root_block_device {
+    volume_size           = var.root_volume_size
+    volume_type           = "gp3"
+    encrypted             = true
+    delete_on_termination = true
+  }
+
+  tags = {
+    Name = "${var.project_name}-${var.env}-rabbitmq"
+    Role = "rabbitmq"
+  }
+}
+
+resource "aws_ssm_parameter" "rabbitmq_be_config" {
+  for_each = {
+    "rabbitmq-enabled"    = "true"
+    "rabbitmq-stomp-host" = aws_instance.rabbitmq.private_ip
+    "rabbitmq-stomp-port" = "61613"
+    "rabbitmq-amqp-host"  = aws_instance.rabbitmq.private_ip
+    "rabbitmq-amqp-port"  = "5672"
+    "rabbitmq-username"   = var.rabbitmq_username
+  }
+
+  name      = "/${var.project_name}/${var.env}/be/${each.key}"
+  type      = "String"
+  value     = each.value
+  overwrite = true
+}
+
+resource "aws_ssm_parameter" "rabbitmq_be_password" {
+  name      = "/${var.project_name}/${var.env}/be/rabbitmq-password"
+  type      = "SecureString"
+  value     = random_password.rabbitmq.result
+  overwrite = true
+}

--- a/shared/rabbitmq/dev/outputs.tf
+++ b/shared/rabbitmq/dev/outputs.tf
@@ -1,0 +1,39 @@
+# shared/rabbitmq/dev/outputs.tf
+
+output "instance_id" {
+  description = "RabbitMQ EC2 인스턴스 ID"
+  value       = aws_instance.rabbitmq.id
+}
+
+output "private_ip" {
+  description = "RabbitMQ Private IP"
+  value       = aws_instance.rabbitmq.private_ip
+}
+
+output "amqp_endpoint" {
+  description = "RabbitMQ AMQP Endpoint"
+  value       = "${aws_instance.rabbitmq.private_ip}:5672"
+}
+
+output "stomp_endpoint" {
+  description = "RabbitMQ STOMP Endpoint"
+  value       = "${aws_instance.rabbitmq.private_ip}:61613"
+}
+
+output "management_url" {
+  description = "RabbitMQ Management URL (VPN/Management CIDR에서만 접근)"
+  value       = "http://${aws_instance.rabbitmq.private_ip}:15672"
+}
+
+output "security_group_id" {
+  description = "RabbitMQ Security Group ID"
+  value       = aws_security_group.rabbitmq.id
+}
+
+output "ssm_parameter_names" {
+  description = "Backend 연동용 SSM 파라미터 목록"
+  value = concat(
+    [for p in aws_ssm_parameter.rabbitmq_be_config : p.name],
+    [aws_ssm_parameter.rabbitmq_be_password.name]
+  )
+}

--- a/shared/rabbitmq/dev/terraform.tfvars.example
+++ b/shared/rabbitmq/dev/terraform.tfvars.example
@@ -1,0 +1,7 @@
+# shared/rabbitmq/dev/terraform.tfvars.example
+
+instance_type = "t3.small"
+key_name      = "billage-keypair"
+
+# 운영 접근 CIDR (Management VPC + DevOps VPN 예시)
+management_access_cidrs = ["10.2.0.0/16", "10.100.0.16/28"]

--- a/shared/rabbitmq/dev/user_data_rabbitmq.sh.tpl
+++ b/shared/rabbitmq/dev/user_data_rabbitmq.sh.tpl
@@ -1,0 +1,40 @@
+#!/bin/bash
+set -euxo pipefail
+
+exec > >(tee /var/log/user-data.log) 2>&1
+echo "=== RabbitMQ bootstrap started at $(date) ==="
+
+dnf update -y
+dnf install -y docker
+systemctl enable --now docker
+
+mkdir -p /opt/rabbitmq
+mkdir -p /var/lib/rabbitmq
+
+cat > /opt/rabbitmq/enabled_plugins <<'PLUGINS'
+[rabbitmq_management,rabbitmq_stomp].
+PLUGINS
+
+docker rm -f billage-rabbitmq || true
+
+docker run -d \
+  --name billage-rabbitmq \
+  --restart unless-stopped \
+  -p 5672:5672 \
+  -p 61613:61613 \
+  -p 15672:15672 \
+  -e RABBITMQ_DEFAULT_USER='${rabbitmq_username}' \
+  -e RABBITMQ_DEFAULT_PASS='${rabbitmq_password}' \
+  -v /var/lib/rabbitmq:/var/lib/rabbitmq \
+  -v /opt/rabbitmq/enabled_plugins:/etc/rabbitmq/enabled_plugins:ro \
+  rabbitmq:3.13-management
+
+for i in {1..30}; do
+  if docker exec billage-rabbitmq rabbitmq-diagnostics -q ping; then
+    echo "RabbitMQ is healthy"
+    break
+  fi
+  sleep 5
+done
+
+echo "=== RabbitMQ bootstrap completed at $(date) ==="

--- a/shared/rabbitmq/dev/variables.tf
+++ b/shared/rabbitmq/dev/variables.tf
@@ -1,0 +1,85 @@
+# shared/rabbitmq/dev/variables.tf
+
+variable "aws_region" {
+  description = "AWS Region"
+  type        = string
+  default     = "ap-northeast-2"
+}
+
+variable "project_name" {
+  description = "프로젝트 이름"
+  type        = string
+  default     = "billage"
+}
+
+variable "env" {
+  description = "환경"
+  type        = string
+  default     = "dev"
+}
+
+variable "instance_type" {
+  description = "RabbitMQ EC2 인스턴스 타입"
+  type        = string
+  default     = "t3.small"
+}
+
+variable "root_volume_size" {
+  description = "RabbitMQ 루트 볼륨 크기(GB)"
+  type        = number
+  default     = 20
+}
+
+variable "key_name" {
+  description = "운영 접근용 키페어 이름"
+  type        = string
+  default     = "billage-keypair"
+}
+
+variable "rabbitmq_username" {
+  description = "RabbitMQ 기본 사용자명"
+  type        = string
+  default     = "billage"
+}
+
+variable "management_access_cidrs" {
+  description = "RabbitMQ Management UI(15672) 접근 허용 CIDR"
+  type        = list(string)
+  default     = ["10.2.0.0/16", "10.100.0.16/28"]
+}
+
+variable "v1_state_bucket" {
+  description = "v1 Dev remote state bucket"
+  type        = string
+  default     = "billage-terraform-state-dev"
+}
+
+variable "v1_state_key" {
+  description = "v1 Dev remote state key"
+  type        = string
+  default     = "dev/terraform.tfstate"
+}
+
+variable "v1_state_lock_table" {
+  description = "v1 Dev remote state lock table"
+  type        = string
+  default     = "billage-terraform-lock-dev"
+}
+
+variable "v2_state_bucket" {
+  description = "v2 Dev remote state bucket"
+  type        = string
+  default     = "billage-terraform-state-dev"
+}
+
+variable "v2_state_key" {
+  description = "v2 Dev remote state key"
+  type        = string
+  default     = "v2/dev/terraform.tfstate"
+}
+
+variable "v2_state_lock_table" {
+  description = "v2 Dev remote state lock table"
+  type        = string
+  default     = "billage-terraform-lock-dev"
+}

--- a/v2/envs/dev/main.tf
+++ b/v2/envs/dev/main.tf
@@ -393,6 +393,7 @@ resource "aws_lb" "main" {
   load_balancer_type = "application"
   security_groups    = [aws_security_group.alb.id]
   subnets            = [data.aws_subnet.public.id, aws_subnet.public_c.id]
+  idle_timeout       = 300 # WebSocket 연결 안정성을 위해 기본(60s)보다 확장
 
   enable_deletion_protection = false
 
@@ -505,6 +506,22 @@ resource "aws_lb_listener" "https" {
 }
 
 # Path based routing
+resource "aws_lb_listener_rule" "ws" {
+  listener_arn = aws_lb_listener.https.arn
+  priority     = 90
+
+  action {
+    type             = "forward"
+    target_group_arn = aws_lb_target_group.backend.arn
+  }
+
+  condition {
+    path_pattern {
+      values = ["/ws/*"]
+    }
+  }
+}
+
 resource "aws_lb_listener_rule" "api" {
   listener_arn = aws_lb_listener.https.arn
   priority     = 100


### PR DESCRIPTION
## 근본 목적
v1(단일 인스턴스)와 v2(ALB+ASG)가 동시에 사용하는 WebSocket Pub/Sub 브로커 기반을 먼저 만들고, v2에서 `/ws/*` 유입 경로를 명시해 무중단 socket 마이그레이션 준비를 시작한다.

## 비목적
- 이번 PR에서 RabbitMQ HA(클러스터/관리형 전환)까지 완료하지 않는다.
- 실제 `terraform apply`는 수행하지 않는다.
- v1/v2 전체 컷오버는 포함하지 않는다.

## 변경 내용
- `shared/rabbitmq/dev` 신규 스택 추가
  - backend state, variables, main, outputs, tfvars.example, user_data 템플릿
  - 단일 RabbitMQ EC2 + SG + IAM profile + SSM 파라미터(`/billage/dev/be/rabbitmq-*`)
  - v1/v2 remote state를 읽어 `v1 main SG`, `v2 backend SG`만 AMQP/STOMP ingress 허용
- `v2/envs/dev/main.tf`
  - ALB `idle_timeout = 300` 설정
  - `/ws/* -> backend target group` listener rule(priority 90) 추가

## 검증
실행 명령:
```bash
terraform -chdir=shared/rabbitmq/dev init -no-color
terraform -chdir=shared/rabbitmq/dev plan -input=false -no-color
terraform -chdir=v2/envs/dev init -no-color
terraform -chdir=v2/envs/dev plan -input=false -no-color -var 'golden_ami_id=ami-01488502d83cfffa4'
```

결과:
- `shared/rabbitmq/dev`: `Plan: 14 to add, 0 to change, 0 to destroy.`
- `v2/envs/dev`: `Plan: 1 to add, 7 to change, 1 to destroy.`

## 참고 사항
- `v2/envs/dev` plan에는 본 PR 변경(`/ws/*`, idle timeout) 외에도 기존 드리프트(launch template user_data, `aws_route53_record.api_v2` state 차이)가 함께 감지된다.
- 요청대로 `apply`는 수행하지 않았다.

Closes #92
