### PR TITLE
[#92 follow-up] RabbitMQ root volume default 30GB 조정

### DIFF
--- a/shared/rabbitmq/dev/terraform.tfvars.example
+++ b/shared/rabbitmq/dev/terraform.tfvars.example
@@ -2,6 +2,7 @@
 
 instance_type = "t3.small"
 key_name      = "billage-keypair"
+root_volume_size = 30
 
 # 운영 접근 CIDR (Management VPC + DevOps VPN 예시)
 management_access_cidrs = ["10.2.0.0/16", "10.100.0.16/28"]

--- a/shared/rabbitmq/dev/variables.tf
+++ b/shared/rabbitmq/dev/variables.tf
@@ -27,7 +27,7 @@ variable "instance_type" {
 variable "root_volume_size" {
   description = "RabbitMQ 루트 볼륨 크기(GB)"
   type        = number
-  default     = 20
+  default     = 30
 }
 
 variable "key_name" {


### PR DESCRIPTION
## 근본 목적
RabbitMQ 단일 인스턴스 bootstrap이 AMI 최소 스냅샷 크기 제약으로 실패하지 않도록, 루트 볼륨 기본값을 안전한 크기로 맞춥니다.

## 비목적
구성 확장(HA/클러스터링)이나 네트워크 토폴로지 변경은 이번 PR 범위가 아닙니다.

## 변경 사항
- shared/rabbitmq/dev/variables.tf
  - root_volume_size 기본값: 20 -> 30
- shared/rabbitmq/dev/terraform.tfvars.example
  - root_volume_size = 30 예시 추가

## 검증
- terraform apply(shared/rabbitmq/dev) 재실행 성공
- v2/envs/dev는 destroy(api_v2 DNS) 회피를 위해 target apply로 변경 반영

## 실서버 테스트 절차 및 결과
대상 인스턴스
- EC2: i-07d789c8059b89a6d
- Private IP: 10.0.20.51
- Region: ap-northeast-2

1) 런타임/포트/플러그인 확인 (SSM)
- docker 컨테이너 상태: billage-rabbitmq Up 확인
- rabbitmq-diagnostics ping: Ping succeeded
- 활성 플러그인: rabbitmq_management, rabbitmq_stomp
- 리스닝 포트: 5672(AMQP), 61613(STOMP), 15672(Management)
- Management endpoint: http://127.0.0.1:15672 응답코드 200

2) 기능 검증 (메시지 publish/get)
- 테스트 큐: ws.healthcheck.q
- queue declare 성공
- payload `hello-ws-pubsub-check` publish 성공
- queue depth 1 확인
- get(ackmode=ack_requeue_false)로 메시지 소비 성공
- 소비 후 queue depth 0 확인

3) 결과
- RabbitMQ 컨테이너 기반 단일 노드가 정상 기동됨
- WS Pub/Sub 용도 핵심 경로(STOMP/AMQP, 관리 포트, 기본 publish/consume)가 동작함

추적용 SSM Command ID
- 기능검증 1차: 46da317b-b12a-4240-9097-7c79a7a89277
- 기능검증 2차(consume 옵션 보정): 797115a1-6f07-4b1f-9b66-e550c9f6f428
