### PR TITLE
[dev-v2] api.dev.billages.com 502 해소를 위한 BE ALB 라우팅

### DIFF
--- a/v2/envs/dev/main.tf
+++ b/v2/envs/dev/main.tf
@@ -535,7 +535,7 @@ resource "aws_lb_listener_rule" "api" {
 
   condition {
     host_header {
-      values = ["api-v2.${var.domain_name}"]
+      values = ["api-v2.${var.domain_name}", "api.${var.env}.${var.domain_name}"]
     }
   }
 }
@@ -928,3 +928,14 @@ resource "aws_route53_record" "api_v2" {
   }
 }
 
+resource "aws_route53_record" "api_dev" {
+  zone_id = data.aws_route53_zone.main.zone_id
+  name    = "api.${var.env}.${var.domain_name}"
+  type    = "A"
+
+  alias {
+    name                   = aws_lb.main.dns_name
+    zone_id                = aws_lb.main.zone_id
+    evaluate_target_health = true
+  }
+}


### PR DESCRIPTION
## 근본 목적
`api.dev.billages.com` 502를 제거하고 dev API 가용성을 즉시 복구한다.

## 비목적
백엔드 애플리케이션 코드/DB/비즈니스 로직 변경은 포함하지 않는다.

## 문제 식별
- `api.dev.billages.com` DNS가 dev-main nginx(43.200.94.221)로 향함
- 해당 nginx는 `localhost:8080`으로 프록시하지만 8080 백엔드 프로세스/컨테이너가 없어 502 발생
- v2 ALB의 BE는 내부적으로 healthy였지만 `api.dev.billages.com` host-header 라우팅과 Route53 연결이 빠져 있었음

## 해결
- dev v2 ALB HTTPS listener rule(`api`) host-header에 `api.dev.billages.com` 추가
- Route53 `api.dev.billages.com` A 레코드를 dev v2 ALB alias로 연결

## 검증
- `curl https://api.dev.billages.com/actuator/health` -> `200`, `{"status":"UP"}`
- `curl https://api.dev.billages.com` -> `401`, `{"code":"AUTH02"}` (정상 인증 미통과 응답)
