### PR TITLE
fix(monitoring): resolve Loki v2 dashboard no-data with All env

### DIFF
--- a/monitoring/server/configs/grafana/dashboards/loki-logs-v2.json
+++ b/monitoring/server/configs/grafana/dashboards/loki-logs-v2.json
@@ -42,7 +42,7 @@
             "type": "loki",
             "uid": "${DS_LOKI}"
           },
-          "expr": "sum by (job) (count_over_time({env=\"$env\"}[1m]))",
+          "expr": "sum by (job) (count_over_time({env=~\"$env\"}[1m]))",
           "refId": "A",
           "legendFormat": "{{job}}"
         }
@@ -91,7 +91,7 @@
             "type": "loki",
             "uid": "${DS_LOKI}"
           },
-          "expr": "sum by (status) (count_over_time({env=\"$env\", job=~\".*nginx.*\", status=~\".+\"}[$__range]))",
+          "expr": "sum by (status) (count_over_time({env=~\"$env\", job=~\".*nginx.*\", status=~\".+\"}[$__range]))",
           "refId": "A",
           "legendFormat": "{{status}}"
         }
@@ -170,7 +170,7 @@
             "type": "loki",
             "uid": "${DS_LOKI}"
           },
-          "expr": "sum(count_over_time({env=\"$env\", job=~\".*nginx.*\", status=~\"5..\"}[1m]))",
+          "expr": "sum(count_over_time({env=~\"$env\", job=~\".*nginx.*\", status=~\"5..\"}[1m]))",
           "refId": "A",
           "legendFormat": "5xx 서버 에러"
         },
@@ -179,7 +179,7 @@
             "type": "loki",
             "uid": "${DS_LOKI}"
           },
-          "expr": "sum(count_over_time({env=\"$env\", job=~\".*nginx.*\", status=~\"4..\"}[1m]))",
+          "expr": "sum(count_over_time({env=~\"$env\", job=~\".*nginx.*\", status=~\"4..\"}[1m]))",
           "refId": "B",
           "legendFormat": "4xx 클라이언트 에러"
         }
@@ -265,7 +265,7 @@
             "type": "loki",
             "uid": "${DS_LOKI}"
           },
-          "expr": "sum(count_over_time({env=\"$env\", job=~\".*(backend|billages-backend).*\", level=\"ERROR\"}[1m]))",
+          "expr": "sum(count_over_time({env=~\"$env\", job=~\".*(backend|billages-backend).*\", level=\"ERROR\"}[1m]))",
           "refId": "A",
           "legendFormat": "ERROR"
         },
@@ -274,7 +274,7 @@
             "type": "loki",
             "uid": "${DS_LOKI}"
           },
-          "expr": "sum(count_over_time({env=\"$env\", job=~\".*(backend|billages-backend).*\", level=\"WARN\"}[1m]))",
+          "expr": "sum(count_over_time({env=~\"$env\", job=~\".*(backend|billages-backend).*\", level=\"WARN\"}[1m]))",
           "refId": "B",
           "legendFormat": "WARN"
         }
@@ -347,7 +347,7 @@
             "type": "loki",
             "uid": "${DS_LOKI}"
           },
-          "expr": "sum(count_over_time({env=\"$env\", job=~\".*(backend|billages-backend).*\", level=\"ERROR\"}[$__range]))",
+          "expr": "sum(count_over_time({env=~\"$env\", job=~\".*(backend|billages-backend).*\", level=\"ERROR\"}[$__range]))",
           "refId": "A",
           "legendFormat": "ERROR"
         },
@@ -356,7 +356,7 @@
             "type": "loki",
             "uid": "${DS_LOKI}"
           },
-          "expr": "sum(count_over_time({env=\"$env\", job=~\".*(backend|billages-backend).*\", level=\"WARN\"}[$__range]))",
+          "expr": "sum(count_over_time({env=~\"$env\", job=~\".*(backend|billages-backend).*\", level=\"WARN\"}[$__range]))",
           "refId": "B",
           "legendFormat": "WARN"
         },
@@ -365,7 +365,7 @@
             "type": "loki",
             "uid": "${DS_LOKI}"
           },
-          "expr": "sum(count_over_time({env=\"$env\", job=~\".*(backend|billages-backend).*\", level=\"INFO\"}[$__range]))",
+          "expr": "sum(count_over_time({env=~\"$env\", job=~\".*(backend|billages-backend).*\", level=\"INFO\"}[$__range]))",
           "refId": "C",
           "legendFormat": "INFO"
         }
@@ -409,7 +409,7 @@
             "type": "loki",
             "uid": "${DS_LOKI}"
           },
-          "expr": "{env=\"$env\", job=~\".*(backend|billages-backend).*\", level=~\"ERROR|WARN\"}",
+          "expr": "{env=~\"$env\", job=~\".*(backend|billages-backend).*\", level=~\"ERROR|WARN\"}",
           "refId": "A"
         }
       ],
@@ -441,7 +441,7 @@
             "type": "loki",
             "uid": "${DS_LOKI}"
           },
-          "expr": "{env=\"$env\", job=~\"$job\"} |~ \"(?i)$search\"",
+          "expr": "{env=~\"$env\", job=~\"$job\"} |~ \"(?i)$search\"",
           "refId": "A"
         }
       ],
@@ -489,7 +489,7 @@
             "type": "loki",
             "uid": "${DS_LOKI}"
           },
-          "expr": "sum by (job) (count_over_time({env=\"$env\"}[1m]))",
+          "expr": "sum by (job) (count_over_time({env=~\"$env\"}[1m]))",
           "refId": "A",
           "legendFormat": "{{job}}"
         }
@@ -530,7 +530,7 @@
             "type": "loki",
             "uid": "${DS_LOKI}"
           },
-          "expr": "sum(count_over_time({env=\"$env\", job=~\".*(backend|billages-backend).*\"} |= \"Exception\" [1m]))",
+          "expr": "sum(count_over_time({env=~\"$env\", job=~\".*(backend|billages-backend).*\"} |= \"Exception\" [1m]))",
           "refId": "A",
           "legendFormat": "Exception/s"
         },
@@ -539,7 +539,7 @@
             "type": "loki",
             "uid": "${DS_LOKI}"
           },
-          "expr": "sum(count_over_time({env=\"$env\", job=~\".*(backend|billages-backend).*\"} |= \"timeout\" [1m]))",
+          "expr": "sum(count_over_time({env=~\"$env\", job=~\".*(backend|billages-backend).*\"} |= \"timeout\" [1m]))",
           "refId": "B",
           "legendFormat": "timeout/s"
         }
@@ -575,7 +575,7 @@
             "type": "loki",
             "uid": "${DS_LOKI}"
           },
-          "expr": "{env=\"$env\", job=~\".*(backend|billages-backend).*\"} |~ \"(?i)(unauthorized|forbidden|access denied|invalid token)\"",
+          "expr": "{env=~\"$env\", job=~\".*(backend|billages-backend).*\"} |~ \"(?i)(unauthorized|forbidden|access denied|invalid token)\"",
           "refId": "A"
         }
       ],
@@ -610,7 +610,7 @@
             "type": "loki",
             "uid": "${DS_LOKI}"
           },
-          "expr": "{env=\"$env\", job=~\"$job\"} |~ \"(?i)(Exception|error|timeout|deadlock|oom|killed)\"",
+          "expr": "{env=~\"$env\", job=~\"$job\"} |~ \"(?i)(Exception|error|timeout|deadlock|oom|killed)\"",
           "refId": "A"
         }
       ],
@@ -648,7 +648,7 @@
         "refresh": 1,
         "hide": 0,
         "includeAll": true,
-        "allValue": ".*",
+        "allValue": ".+",
         "multi": true,
         "options": [
           {
@@ -676,7 +676,7 @@
           "type": "loki",
           "uid": "${DS_LOKI}"
         },
-        "query": "label_values({env=\"$env\"}, job)",
+        "query": "label_values({env=~\"$env\"}, job)",
         "sort": 1,
         "refresh": 1,
         "hide": 0,


### PR DESCRIPTION
## 배경
v2 Loki 대시보드에서 env 변수 기본값이 All일 때 패널이 No data로 보이는 문제가 있었습니다.

## 원인
- env 변수 All 값이 .* 인데
- 쿼리에서 env="$env"(정확 일치)로 사용되어 env=".*" 라벨을 찾게 됨

## 변경 내용
- monitoring/server/configs/grafana/dashboards/loki-logs-v2.json
- 모든 Loki selector의 env 매칭을 env="$env" -> env=~"$env" 로 변경
- env 템플릿 변수의 allValue를 .* -> .+ 로 보정
- job 변수 조회 쿼리를 label_values({env=~"$env"}, job) 로 변경

## 검증
- Loki API에서 job=backend, env=dev 로그 유입 확인
- Grafana 대시보드 로딩 후 env=All 상태에서 쿼리 정상 동작 확인

## 참고
- 이번 PR에는 Grafana 계정/비밀번호 관련 변경은 포함하지 않았습니다.
- 운영 환경에서의 일시적 로그인 잠금 해제 조치는 코드 변경과 분리되어 있습니다.
