### PR TITLE
chore(monitoring): sync VPC dashboard with live server

### DIFF
--- a/monitoring/server/configs/grafana/dashboards/vpc-monitoring.json
+++ b/monitoring/server/configs/grafana/dashboards/vpc-monitoring.json
@@ -14,25 +14,6 @@
         "type": "loki",
         "uid": "loki"
       },
-      "fieldConfig": {
-        "defaults": {
-          "color": {
-            "mode": "palette-classic"
-          },
-          "mappings": [],
-          "thresholds": {
-            "mode": "absolute",
-            "steps": [
-              {
-                "color": "green",
-                "value": null
-              }
-            ]
-          },
-          "unit": "short"
-        },
-        "overrides": []
-      },
       "gridPos": {
         "h": 4,
         "w": 6,
@@ -71,24 +52,6 @@
       "datasource": {
         "type": "loki",
         "uid": "loki"
-      },
-      "fieldConfig": {
-        "defaults": {
-          "color": {
-            "mode": "palette-classic"
-          },
-          "mappings": [],
-          "thresholds": {
-            "mode": "absolute",
-            "steps": [
-              {
-                "color": "green",
-                "value": null
-              }
-            ]
-          }
-        },
-        "overrides": []
       },
       "gridPos": {
         "h": 4,
@@ -186,7 +149,7 @@
             "type": "loki",
             "uid": "loki"
           },
-          "expr": "{job=\"vpn-traffic\", role=~\"$role\"} | line_format \"[{{.role}}] {{.src_ip}} -> {{.dst_ip}}:{{.dst_port}} ({{.protocol}})\"",
+          "expr": "{job=\"vpn-traffic\", role=~\".*\"} | regexp \"SRC=(?P<src_ip>[^ ]+) DST=(?P<dst_ip>[^ ]+) .* PROTO=(?P<protocol>[^ ]+) .* DPT=(?P<dst_port>[^ ]+)\" | line_format \"[{{.role}}] {{.src_ip}} -> {{.dst_ip}}:{{.dst_port}} ({{.protocol}})\"",
           "queryType": "range",
           "refId": "A"
         }
@@ -198,31 +161,6 @@
       "datasource": {
         "type": "loki",
         "uid": "loki"
-      },
-      "fieldConfig": {
-        "defaults": {
-          "color": {
-            "mode": "thresholds"
-          },
-          "custom": {
-            "align": "auto",
-            "cellOptions": {
-              "type": "auto"
-            },
-            "inspect": false
-          },
-          "mappings": [],
-          "thresholds": {
-            "mode": "absolute",
-            "steps": [
-              {
-                "color": "green",
-                "value": null
-              }
-            ]
-          }
-        },
-        "overrides": []
       },
       "gridPos": {
         "h": 8,
@@ -248,7 +186,7 @@
             "type": "loki",
             "uid": "loki"
           },
-          "expr": "topk(10, sum by (role, src_ip, dst_ip, dst_port) (count_over_time({job=\"vpn-traffic\", role=~\"$role\"} [$__range])))",
+          "expr": "topk(10, sum by (role, src_ip, dst_ip, dst_port) (count_over_time({job=\"vpn-traffic\", role=~\".*\"} | regexp \"SRC=(?P<src_ip>[^ ]+) DST=(?P<dst_ip>[^ ]+) .* PROTO=(?P<protocol>[^ ]+) .* DPT=(?P<dst_port>[^ ]+)\" [$__range])))",
           "queryType": "instant",
           "refId": "A"
         }
@@ -290,7 +228,7 @@
             "type": "loki",
             "uid": "loki"
           },
-          "expr": "{job=\"vpn-traffic\", role=~\"$role\", dst_port=~\"22|3306|5432|6379|27017\"} | line_format \"[SECURITY][{{.role}}] {{.src_ip}} -> {{.dst_ip}}:{{.dst_port}}\"",
+          "expr": "{job=\"vpn-traffic\", role=~\".*\", dst_port=~\"22|3306|5432|6379|27017\"} | regexp \"SRC=(?P<src_ip>[^ ]+) DST=(?P<dst_ip>[^ ]+) .* PROTO=(?P<protocol>[^ ]+) .* DPT=(?P<dst_port>[^ ]+)\" | line_format \"[SECURITY][{{.role}}] {{.src_ip}} -> {{.dst_ip}}:{{.dst_port}}\"",
           "queryType": "range",
           "refId": "A"
         }
@@ -321,31 +259,6 @@
             "selected": true,
             "text": "All",
             "value": ".*"
-          },
-          {
-            "selected": false,
-            "text": "DevOps",
-            "value": "devops"
-          },
-          {
-            "selected": false,
-            "text": "Backend",
-            "value": "backend"
-          },
-          {
-            "selected": false,
-            "text": "Frontend",
-            "value": "frontend"
-          },
-          {
-            "selected": false,
-            "text": "AI/ML",
-            "value": "aiml"
-          },
-          {
-            "selected": false,
-            "text": "Unknown",
-            "value": "unknown"
           }
         ],
         "query": "",
@@ -362,6 +275,6 @@
   "timezone": "Asia/Seoul",
   "title": "VPN Monitoring Dashboard",
   "uid": "billages-vpn-monitoring",
-  "version": 2,
+  "version": 6,
   "weekStart": ""
 }


### PR DESCRIPTION
## 근본 목적
모니터링 서버에서 실제 Grafana가 로드 중인 `vpc-monitoring.json` 파일 상태를 저장소에 반영해, 로컬 Git 기준과 live 대시보드 구성이 어긋나는 관측 공백을 해소한다.

## 비목적
이번 PR은 대시보드 쿼리 개편이나 신규 모니터링 기능 추가가 목적이 아니며, 서버 설정 변경이나 Grafana 프로비저닝 구조 변경은 포함하지 않는다.

## 변경 내용
- tracked 파일 `vpn-monitoring.json` 을 live 서버 기준 파일명 `vpc-monitoring.json` 으로 정리
- live monitoring server의 실제 파일 내용과 동일한 대시보드 JSON 반영

## Verification
- `git diff --summary origin/main..feature/sync-vpc-monitoring-dashboard-124` 기준 rename 확인
- 로컬 `shasum monitoring/server/configs/grafana/dashboards/vpc-monitoring.json`
- 서버 `ssh ubuntu@10.2.2.42 "shasum /home/ubuntu/monitoring-server/configs/grafana/dashboards/vpc-monitoring.json"`
- 두 SHA1 동일 확인

## 이슈
- Closes #124